### PR TITLE
修改README.md中的声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Minecraft © Mojang AB / Microsoft Corporation. All Rights Reserved.
 
 本文档引用的游戏截图、纹理、源码等内容受著作权法保护，在符合[Minecraft EULA](https://www.minecraft.net/zh-hans/eula)和[Minecraft 使用准则](https://www.minecraft.net/zh-hans/usage-guidelines)的前提下进行有限引用。
 
-其中，本文档引用的源码来源于对Minecraft的反编译研究，使用了[Yarn映射表](https://github.com/FabricMC/yarn)进行可读化反编译。该映射表采用[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.zh-hans)授权。
+其中，本文档引用的源码来源于对Minecraft的反编译研究，使用了[Yarn映射表](https://github.com/FabricMC/yarn)进行可读化反编译，该映射表采用[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.zh-hans)授权。
 
 本文档不构成对Minecraft游戏代码的再分发或任何形式的商业使用，也不提供可直接运行的完整游戏代码或可执行文件。所有对游戏内部机制的描述均限于学习和说明目的。
 
@@ -46,6 +46,7 @@ GTMC Wiki Team:
 - 鸣谢 / Graduate texts in technical MC, Fallen_Breath, 五羊飞kaniol
 
 **本文档并非Minecraft官方文档，与Mojang和微软亦无从属关系。**
+
 **Not an official Minecraft document. We are not associated with Mojang or Microsoft.**
 
 [^1]: 像这样

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
 
 可以来QQ裙吹水：1031431170
 
-## 开源协议与著作权声明
+## 许可协议与著作权声明
 
-文档全部基于[CC BY-NC-SA 4.0协议](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-hans)开源。Copyright © 2024 ABxl_lly, BFladderbean, Molforte, Ryan100c, tanh_Heng, Twisuki, xhbsh, yuhan2680. All Rights Reserved.
+本文档内容采用[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-hans)授权。Copyright © 2024 GTMC Team.
 
-Email: <tanh_heng@outlook.com>, <fannbryan@gmail.com>, <yuhan2680@qq.com>，<suyang233@hotmail.com>，<Molforte@outlook.com>
+联系邮箱: <tanh_heng@outlook.com>, <fannbryan@gmail.com>, <yuhan2680@qq.com>，<suyang233@hotmail.com>，<Molforte@outlook.com>
 
 - 作者 / ABxl_lly, BFladderbean, Molforte, Ryan100c, tanh_Heng, Twisuki, xhbsh , yuhan2680
 - 协作 / Petris, void, XJH_Jorhai

--- a/README.md
+++ b/README.md
@@ -24,28 +24,29 @@
 
 可以来QQ裙吹水：1031431170
 
-## 许可协议与著作权声明
+## 著作权声明与授权信息
 
-本文档内容采用[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.zh-hans)授权。Copyright © 2024 GTMC Team.
+Copyright © 2024 GTMC Wiki.
+本文档原创内容采用[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh-hans)授权。
+
+Minecraft® 是 Mojang AB 的注册商标。
+Minecraft © Mojang AB / Microsoft Corporation. All Rights Reserved.
+
+本文档引用的游戏截图、纹理、源码等内容受著作权法保护，在符合[Minecraft EULA](https://www.minecraft.net/zh-hans/eula)和[Minecraft 使用准则](https://www.minecraft.net/zh-hans/usage-guidelines)的前提下进行有限引用。
+
+其中，本文档引用的源码来源于对Minecraft的反编译研究，使用了[Yarn映射表](https://github.com/FabricMC/yarn)进行可读化反编译。该映射表采用[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.zh-hans)授权。
+
+本文档不构成对Minecraft游戏代码的再分发或任何形式的商业使用，也不提供可直接运行的完整游戏代码或可执行文件。所有对游戏内部机制的描述均限于学习和说明目的。
 
 联系邮箱: <tanh_heng@outlook.com>, <fannbryan@gmail.com>, <yuhan2680@qq.com>，<suyang233@hotmail.com>，<Molforte@outlook.com>
 
+GTMC Wiki Team:
 - 作者 / ABxl_lly, BFladderbean, Molforte, Ryan100c, tanh_Heng, Twisuki, xhbsh , yuhan2680
 - 协作 / Petris, void, XJH_Jorhai
 - 鸣谢 / Graduate texts in technical MC, Fallen_Breath, 五羊飞kaniol
 
-## EULA声明
-
-我们严格遵守[Minecraft EULA](https://www.minecraft.net/en-us/eula)协议：
-```
-However, you must not distribute anything we've made unless we specifically agree to it. By "distribute anything we've made" what we mean is:
-
-give copies of our game software or content to anyone else;
-make commercial use of anything we've made;
-try to make money from anything we've made; or
-let other people get access to anything we've made in a way that is unfair or unreasonable.
-```
-本文档中所有引用的代码均只作学习作用，无任何商业用途或试图损害Microsoft或Mojang利益的目的。
+**本文档并非Minecraft官方文档，与Mojang和微软亦无从属关系。**
+**Not an official Minecraft document. We are not associated with Mojang or Microsoft.**
 
 [^1]: 像这样
 [^2]: 像像这这样样


### PR DESCRIPTION
1. 修改对CC协议的称呼，因为CC并不是一种典型意义上的开源协议，其也无法较好的适用于自由软件，故将其统称为授权。
2. CC协议本身是一种“Some Rights Reserved”（保留部分权利），这在CC基金会的FAQ中也有提到，参见[该段落](https://creativecommons.org/faq/#what-does-some-rights-reserved-mean)。在声明使用CC授权后又同时声明“All Rights Reserved”可能导致潜在的问题。故删除ARR描述但保留版权声明。
3. 同时对使用的游戏文件/映射表进行版权声明。
4. 将Minecraft EULA和Minecraft 使用准则进行并列，并声明符合合理有限使用原则。
5. 将版权所有对象改为“GTMC Wiki”避免版权声明过长，并在下文明确GTMC Wiki成员。
6. 增加免责声明。



