### PR TITLE
fix(markdown): Decode relative image paths once

### DIFF
--- a/lib/markdown/image-component.tsx
+++ b/lib/markdown/image-component.tsx
@@ -3,6 +3,14 @@ import { ArticleImage } from "@/components/markdown/article-image"
 import type { MarkdownComponentProps } from "@/lib/markdown/component-types"
 import { hasExplicitUrlScheme } from "./url-utils"
 
+function decodeImageSource(src: string): string {
+  try {
+    return decodeURI(src)
+  } catch {
+    return src
+  }
+}
+
 export function createImageComponent(rawPath: string) {
   function ImageComponent({ src: initialSrc, alt }: MarkdownComponentProps) {
     let src = (initialSrc as string) || ""
@@ -13,7 +21,9 @@ export function createImageComponent(rawPath: string) {
         (!src.startsWith("http") && !src.startsWith("/")))
     ) {
       const currentDir = path.dirname("/" + rawPath).replace(/^\/+/, "")
-      const resolved = path.join(currentDir, src).replaceAll("\\", "/")
+      const resolved = path
+        .join(currentDir, decodeImageSource(src))
+        .replaceAll("\\", "/")
       src = `/api/assets?path=${encodeURIComponent(resolved)}`
     }
     return <ArticleImage src={src} alt={(alt as string) || ""} />


### PR DESCRIPTION
## Summary

Fix broken article images whose relative Markdown destinations contain Unicode or percent-encoded characters.

## Root Cause

`react-markdown` normalizes non-ASCII image destinations into percent-encoded URLs. The image component resolved that value and then called `encodeURIComponent` on it again, encoding `%` as `%25`.

As a result, `/api/assets` received paths such as:

```text
01-%25E5%25B9%25B3...
```

instead of:

```text
01-%E5%B9%B3...
```

GitHub could not find the resulting path, so the image request returned 404.

## Changes

- Decode URI-normalized relative image sources before resolving them.
- Encode the resolved asset path exactly once for `/api/assets`.
- Preserve external and absolute image URLs.
- Gracefully preserve malformed percent escapes instead of failing rendering.

## Verification

- `pnpm check`
- `pnpm test`
- 85 tests passed
- Verified Unicode article image paths return `200 image/png`.
- Verified percent-encoded space paths return `200 image/png`.

## Scope

This change only affects the GTMC Markdown image renderer. No article content, submodule pointer, dependency, or generated artifact was changed.
